### PR TITLE
Update Blazor components limitations

### DIFF
--- a/en/blazor-support.md
+++ b/en/blazor-support.md
@@ -53,9 +53,11 @@ Generating Blazor application has the following limitations:
 
 Generated components have these limitations:
 - Card:
-    - cannot generate reversed actions.
-    - cannot generate divider in actions column card type.
-- Navigation Bar - cannot generate title.
+    - reversed actions are not reflected in generated code.
+    - divider in actions column card type is not reflected in generated code.
+- Navigation Bar - when type is set to Content+Actions:
+    - title is not reflected in generated code.
+    - content is not reflected in generated code.
 - Navigation Drawer - does not support pin state and pin threshold.
 - Avatar:
     - initials type shows entire contend instead of first two chars.
@@ -64,8 +66,8 @@ Generated components have these limitations:
     - does not support dialog mode.
     - does not support months.
     - does not support action buttons.
-- Icon Button - does not generate `IgbIconButton`, but `IgbButton` with icon and not text. Generated `IgbButton` has square ripple.
-- Input Group - when is in date type:
+- Icon Button - does not generate `IgbIconButton`, but `IgbButton` with icon and no text. Generated `IgbButton` has square ripple.
+- Input Group - when type is set to date:
     - does not support input format.
     - does not fully support display formats.
     - does not support help text.
@@ -74,9 +76,9 @@ Generated components have these limitations:
     - does not support value loop.
 - Radio Group - does not support required.
 - Grid:
-    - cannot generate advanced filtering.
+    - advanced filtering is not reflected in generated code.
     - does not support column selection.
-    - cannot generate toolbar.
+    - toolbar is not reflected in generated code.
     - does not support exporting.
     - does not support paging.
     - does not support row actions.

--- a/en/blazor-support.md
+++ b/en/blazor-support.md
@@ -55,37 +55,40 @@ Generated components have the following limitations:
 
 - Card:
     - reversed actions are not reflected in generated code.
-    - divider in actions column card type is not reflected in generated code.
-- Navigation Bar - when type is set to Content+Actions:
-    - title is not reflected in generated code.
-    - content is not reflected in generated code.
-- Navigation Drawer - does not support pin state and pin threshold.
+    - divider in "Actions-column" type is not reflected in generated code.
+- Navigation Bar
+    - when type is set to "Content+Actions" title and content are not reflected in generated code.
+- Navigation Drawer
+    - does not support pin state and pin threshold.
 - Avatar:
-    - initials type shows entire contend instead of first two chars.
-- Icon - does not use `IgbIcon` in generated code. All components, which internally use Icon, are not generated with `IgbIcon`.
+    - the "Initials" type does not limit the content to the first two chars.
+- Icon
+    - does not use `IgbIcon` in generated code. All components, which use icons, are also not generated with `IgbIcon`.
 - Date Picker:
-    - does not support dialog mode.
-    - does not support months.
+    - does not support Dialog mode.
+    - does not support displaying multiple months.
     - does not support action buttons.
-- Icon Button - does not generate `IgbIconButton`, but `IgbButton` with icon and no text. Generated `IgbButton` has square ripple.
-- Input Group - when type is set to date:
+- Icon Button
+    - does not generate `IgbIconButton`, but `IgbButton` with icon instead.
+- Input Group - when type is set to "Date":
     - does not support input format.
     - does not fully support display formats.
     - does not support help text.
     - does not support custom prefix and suffix.
     - does not support min and max values.
     - does not support value loop.
-- Radio Group - does not support required.
+- Radio Group
+    - does not support required.
 - Grid:
     - advanced filtering is not reflected in generated code.
-    - does not support column selection.
     - toolbar is not reflected in generated code.
+    - does not support column selection.
     - does not support exporting.
     - does not support paging.
     - does not support row actions.
     - does not support quick filtering.
 
-Additional information about all supported components for Blazor you can find in [Generate App](generate-app/generate-app-overview.md#supported-components)
+For a list of all supported components see [Generate App](generate-app/generate-app-overview.md#supported-components)
 
 ## Additional Resources
 

--- a/en/blazor-support.md
+++ b/en/blazor-support.md
@@ -52,12 +52,38 @@ Generating Blazor application has the following limitations:
 - Bootstrap is turned off in the generated application for now.
 
 Generated components have these limitations:
-- Navigation drawer works only in the overlay state. The mini version does not work too.
-- Date picker works only in dropdown mode.
-- The input group does not support date type.
-- Radio group does not support horizontal mode.
-- Grid cannot generate a toolbar. This disallows the generation of advanced filtering, exporting, pinning, and hiding. Setting cell and row selection do not work simultaneously. Column selection, paging, grouping, and column moving are not supported yet. Filtering is working only in excel style mode.
-- For all components toggle actions are not generated yet.
+- Card:
+    - cannot generate reversed actions.
+    - cannot generate divider in actions column card type.
+- Navigation Bar - cannot generate title.
+- Navigation Drawer - does not support pin state and pin threshold.
+- Avatar:
+    - does not use IgbIcon in generated code.
+    - initials type shows entire contend instead of first two chars.
+- Icon - does not use IgbIcon in generated code.
+- Date Picker:
+    - does not support dialog mode.
+    - does not support months.
+    - does not support action buttons.
+- Floating Action Button - does not use IgbIcon in generated code.
+- Icon Button - does not use IgbIcon in generated code.
+- Input - when is in date type:
+    - does not support input format.
+    - does not fully support display formats.
+    - does not support help text.
+    - does not support custom prefix and suffix.
+    - does not support min and max values.
+    - does not support value loop.
+- Radio Group - does not support required.
+- Grid:
+    - cannot generate advanced filtering.
+    - does not support column selection.
+    - cannot generate toolbar.
+    - does not support exporting.
+    - does not support paging.
+    - does not support row actions.
+    - does not support quick filtering.
+- Badge - does not use IgbIcon in generated code.
 
 Additional information about all supported components for Blazor you can find in [Generate App](generate-app/generate-app-overview.md#supported-components)
 

--- a/en/blazor-support.md
+++ b/en/blazor-support.md
@@ -58,16 +58,14 @@ Generated components have these limitations:
 - Navigation Bar - cannot generate title.
 - Navigation Drawer - does not support pin state and pin threshold.
 - Avatar:
-    - does not use IgbIcon in generated code.
     - initials type shows entire contend instead of first two chars.
-- Icon - does not use IgbIcon in generated code.
+- Icon - does not use `IgbIcon` in generated code. All components, which internally use Icon, are not generated with `IgbIcon`.
 - Date Picker:
     - does not support dialog mode.
     - does not support months.
     - does not support action buttons.
-- Floating Action Button - does not use IgbIcon in generated code.
-- Icon Button - does not use IgbIcon in generated code.
-- Input - when is in date type:
+- Icon Button - does not generate `IgbIconButton`, but `IgbButton` with icon and not text. Generated `IgbButton` has square ripple.
+- Input Group - when is in date type:
     - does not support input format.
     - does not fully support display formats.
     - does not support help text.
@@ -83,7 +81,6 @@ Generated components have these limitations:
     - does not support paging.
     - does not support row actions.
     - does not support quick filtering.
-- Badge - does not use IgbIcon in generated code.
 
 Additional information about all supported components for Blazor you can find in [Generate App](generate-app/generate-app-overview.md#supported-components)
 

--- a/en/generate-app/generate-app-overview.md
+++ b/en/generate-app/generate-app-overview.md
@@ -29,53 +29,53 @@ The design and development user story will be completed once the application is 
 ## Supported Components
 
 Right now AppBuilder generates application for Angular and Blazor. Below is a list of each supported components in each platform:
-| Component              | Angular            | Blazor             |
-|------------------------|--------------------|--------------------|
-| **Layouts**                                                      |
-| Absolute Layout        | :heavy_check_mark: | :heavy_check_mark: |
-| Card                   | :heavy_check_mark: | :warning:          |
-| Column Layout          | :heavy_check_mark: | :heavy_check_mark: |
-| Expansion Panel        | :heavy_check_mark: | :x:                |
-| Row Layout             | :heavy_check_mark: | :heavy_check_mark: |
-| Tab Layout             | :heavy_check_mark: | :x:                |
-| **Menu and Navigation**                                          |
-| Navigation Bar         | :heavy_check_mark: | :warning:          |
-| Navigation Drawer      | :heavy_check_mark: | :warning:          |
-| Views Container        | :heavy_check_mark: | :heavy_check_mark: |
-| **Content**                                                      |
-| Avatar                 | :heavy_check_mark: | :warning:          |
-| Calendar               | :heavy_check_mark: | :x:                |
-| Chip                   | :heavy_check_mark: | :x:                |
-| Icon                   | :heavy_check_mark: | :warning:          |
-| Image                  | :heavy_check_mark: | :heavy_check_mark: |
-| Link                   | :heavy_check_mark: | :heavy_check_mark: |
-| Text                   | :heavy_check_mark: | :heavy_check_mark: |
-| Title                  | :heavy_check_mark: | :heavy_check_mark: |
-| **Input & Forms**                                                |
-| Button                 | :heavy_check_mark: | :heavy_check_mark: |
-| Button Group           | :heavy_check_mark: | :x:                |
-| Checkbox               | :heavy_check_mark: | :heavy_check_mark: |
-| Combo                  | :heavy_check_mark: | :x:                |
-| Date Picker            | :heavy_check_mark: | :warning:          |
-| Drop Down              | :heavy_check_mark: | :x:                |
-| Floating Action Button | :heavy_check_mark: | :warning:          |
-| Icon Button            | :heavy_check_mark: | :warning:          |
-| Input Group            | :heavy_check_mark: | :warning:          |
-| Radio Group            | :heavy_check_mark: | :warning:          |
-| Select                 | :heavy_check_mark: | :x:                |
-| Slider                 | :heavy_check_mark: | :x:                |
-| Switch                 | :heavy_check_mark: | :heavy_check_mark: |
-| Text Area              | :heavy_check_mark: | :x:                |
-| **Grids & Lists**                                                |
-| Grid                   | :heavy_check_mark: | :warning:          |
-| List                   | :heavy_check_mark: | :heavy_check_mark: |
-| **Notifications**                                                |
-| Badge                  | :heavy_check_mark: | :warning:          |
-| Banner                 | :heavy_check_mark: | :x:                |
-| Dialog Window          | :heavy_check_mark: | :x:                |
-| Snackbar               | :heavy_check_mark: | :x:                |
+| Component              | Angular            | Blazor                           |
+|------------------------|--------------------|----------------------------------|
+| **Layouts**                                                                    |
+| Absolute Layout        | :heavy_check_mark: | :heavy_check_mark:               |
+| Card                   | :heavy_check_mark: | :heavy_check_mark::construction: |
+| Column Layout          | :heavy_check_mark: | :heavy_check_mark:               |
+| Expansion Panel        | :heavy_check_mark: | :x:                              |
+| Row Layout             | :heavy_check_mark: | :heavy_check_mark:               |
+| Tab Layout             | :heavy_check_mark: | :x:                              |
+| **Menu and Navigation**                                                        |
+| Navigation Bar         | :heavy_check_mark: | :heavy_check_mark::construction: |
+| Navigation Drawer      | :heavy_check_mark: | :heavy_check_mark::construction: |
+| Views Container        | :heavy_check_mark: | :heavy_check_mark:               |
+| **Content**                                                                    |
+| Avatar                 | :heavy_check_mark: | :heavy_check_mark::construction: |
+| Calendar               | :heavy_check_mark: | :x:                              |
+| Chip                   | :heavy_check_mark: | :x:                              |
+| Icon                   | :heavy_check_mark: | :heavy_check_mark::construction: |
+| Image                  | :heavy_check_mark: | :heavy_check_mark:               |
+| Link                   | :heavy_check_mark: | :heavy_check_mark:               |
+| Text                   | :heavy_check_mark: | :heavy_check_mark:               |
+| Title                  | :heavy_check_mark: | :heavy_check_mark:               |
+| **Input & Forms**                                                              |
+| Button                 | :heavy_check_mark: | :heavy_check_mark:               |
+| Button Group           | :heavy_check_mark: | :x:                              |
+| Checkbox               | :heavy_check_mark: | :heavy_check_mark:               |
+| Combo                  | :heavy_check_mark: | :x:                              |
+| Date Picker            | :heavy_check_mark: | :heavy_check_mark::construction: |
+| Drop Down              | :heavy_check_mark: | :x:                              |
+| Floating Action Button | :heavy_check_mark: | :heavy_check_mark:               |
+| Icon Button            | :heavy_check_mark: | :heavy_check_mark::construction: |
+| Input Group            | :heavy_check_mark: | :heavy_check_mark::construction: |
+| Radio Group            | :heavy_check_mark: | :heavy_check_mark::construction: |
+| Select                 | :heavy_check_mark: | :x:                              |
+| Slider                 | :heavy_check_mark: | :x:                              |
+| Switch                 | :heavy_check_mark: | :heavy_check_mark:               |
+| Text Area              | :heavy_check_mark: | :x:                              |
+| **Grids & Lists**                                                              |
+| Grid                   | :heavy_check_mark: | :heavy_check_mark::construction: |
+| List                   | :heavy_check_mark: | :heavy_check_mark:               |
+| **Notifications**                                                              |
+| Badge                  | :heavy_check_mark: | :heavy_check_mark:               |
+| Banner                 | :heavy_check_mark: | :x:                              |
+| Dialog Window          | :heavy_check_mark: | :x:                              |
+| Snackbar               | :heavy_check_mark: | :x:                              |
 
-> Note: Partially generated components are marked with :warning:. See [Blazor Support](../blazor-support.md#known-issues-and-limitations) for more details on the known issues and limitations for the Blazor components.
+> Note: Partially generated components are marked with :heavy_check_mark::construction:. See [Blazor Support](../blazor-support.md#known-issues-and-limitations) for more details on the known issues and limitations for the Blazor components.
 
 ## Additional Resources
 

--- a/en/generate-app/generate-app-overview.md
+++ b/en/generate-app/generate-app-overview.md
@@ -33,49 +33,49 @@ Right now AppBuilder generates application for Angular and Blazor. Below is a li
 |------------------------|--------------------|--------------------|
 | **Layouts**                                                      |
 | Absolute Layout        | :heavy_check_mark: | :heavy_check_mark: |
-| Card                   | :heavy_check_mark: | :question:         |
+| Card                   | :heavy_check_mark: | :warning:          |
 | Column Layout          | :heavy_check_mark: | :heavy_check_mark: |
 | Expansion Panel        | :heavy_check_mark: | :x:                |
 | Row Layout             | :heavy_check_mark: | :heavy_check_mark: |
 | Tab Layout             | :heavy_check_mark: | :x:                |
 | **Menu and Navigation**                                          |
-| Navigation Bar         | :heavy_check_mark: | :question:         |
-| Navigation Drawer      | :heavy_check_mark: | :question:         |
-| Views Container        | :heavy_check_mark: | :question: |
+| Navigation Bar         | :heavy_check_mark: | :warning:          |
+| Navigation Drawer      | :heavy_check_mark: | :warning:          |
+| Views Container        | :heavy_check_mark: | :heavy_check_mark: |
 | **Content**                                                      |
-| Avatar                 | :heavy_check_mark: | :question:         |
+| Avatar                 | :heavy_check_mark: | :warning:          |
 | Calendar               | :heavy_check_mark: | :x:                |
 | Chip                   | :heavy_check_mark: | :x:                |
-| Icon                   | :heavy_check_mark: | :question:         |
-| Image                  | :heavy_check_mark: | :question:         |
-| Link                   | :heavy_check_mark: | :question:         |
-| Text                   | :heavy_check_mark: | :question:         |
-| Title                  | :heavy_check_mark: | :question:         |
+| Icon                   | :heavy_check_mark: | :warning:          |
+| Image                  | :heavy_check_mark: | :heavy_check_mark: |
+| Link                   | :heavy_check_mark: | :heavy_check_mark: |
+| Text                   | :heavy_check_mark: | :heavy_check_mark: |
+| Title                  | :heavy_check_mark: | :heavy_check_mark: |
 | **Input & Forms**                                                |
-| Button                 | :heavy_check_mark: | :question:         |
+| Button                 | :heavy_check_mark: | :heavy_check_mark: |
 | Button Group           | :heavy_check_mark: | :x:                |
-| Checkbox               | :heavy_check_mark: | :question:         |
+| Checkbox               | :heavy_check_mark: | :heavy_check_mark: |
 | Combo                  | :heavy_check_mark: | :x:                |
-| Date Picker            | :heavy_check_mark: | :question:         |
+| Date Picker            | :heavy_check_mark: | :warning:          |
 | Drop Down              | :heavy_check_mark: | :x:                |
-| Floating Action Button | :heavy_check_mark: | :question:         |
-| Icon Button            | :heavy_check_mark: | :question:         |
-| Input Group            | :heavy_check_mark: | :question:         |
-| Radio Group            | :heavy_check_mark: | :question:         |
+| Floating Action Button | :heavy_check_mark: | :warning:          |
+| Icon Button            | :heavy_check_mark: | :warning:          |
+| Input Group            | :heavy_check_mark: | :warning:          |
+| Radio Group            | :heavy_check_mark: | :warning:          |
 | Select                 | :heavy_check_mark: | :x:                |
 | Slider                 | :heavy_check_mark: | :x:                |
-| Switch                 | :heavy_check_mark: | :question:         |
+| Switch                 | :heavy_check_mark: | :heavy_check_mark: |
 | Text Area              | :heavy_check_mark: | :x:                |
 | **Grids & Lists**                                                |
-| Grid                   | :heavy_check_mark: | :question:         |
-| List                   | :heavy_check_mark: | :question:         |
+| Grid                   | :heavy_check_mark: | :warning:          |
+| List                   | :heavy_check_mark: | :heavy_check_mark: |
 | **Notifications**                                                |
-| Badge                  | :heavy_check_mark: | :question:         |
+| Badge                  | :heavy_check_mark: | :warning:          |
 | Banner                 | :heavy_check_mark: | :x:                |
 | Dialog Window          | :heavy_check_mark: | :x:                |
 | Snackbar               | :heavy_check_mark: | :x:                |
 
-> Note: Partially generated components are marked with :question:. See [Blazor Support](../blazor-support.md#known-issues-and-limitations) for more details on the known issues and limitations for the Blazor components.
+> Note: Partially generated components are marked with :warning:. See [Blazor Support](../blazor-support.md#known-issues-and-limitations) for more details on the known issues and limitations for the Blazor components.
 
 ## Additional Resources
 

--- a/en/generate-app/generate-app-overview.md
+++ b/en/generate-app/generate-app-overview.md
@@ -75,7 +75,7 @@ Right now AppBuilder generates application for Angular and Blazor. Below is a li
 | Dialog Window          | :heavy_check_mark: | :x:                              |
 | Snackbar               | :heavy_check_mark: | :x:                              |
 
-> Note: Partially generated components are marked with :heavy_check_mark::construction:. See [Blazor Support](../blazor-support.md#known-issues-and-limitations) for more details on the known issues and limitations for the Blazor components.
+> Note: Partially generated components are marked with :construction:. See [Blazor Support](../blazor-support.md#known-issues-and-limitations) for more details on the known issues and limitations for the Blazor components.
 
 ## Additional Resources
 

--- a/en/generate-app/generate-app-overview.md
+++ b/en/generate-app/generate-app-overview.md
@@ -28,7 +28,7 @@ The design and development user story will be completed once the application is 
 
 ## Supported Components
 
-Right now AppBuilder generates application for Angular and Blazor. Below is a list of each supported components in each platform:
+Currently, the App Builder supports code generation for Angular and Blazor. Below is a list of supported components per platform:
 | Component              | Angular            | Blazor                           |
 |------------------------|--------------------|----------------------------------|
 | **Layouts**                                                                    |
@@ -75,7 +75,7 @@ Right now AppBuilder generates application for Angular and Blazor. Below is a li
 | Dialog Window          | :heavy_check_mark: | :x:                              |
 | Snackbar               | :heavy_check_mark: | :x:                              |
 
-> Note: Partially generated components are marked with :construction:. See [Blazor Support](../blazor-support.md#known-issues-and-limitations) for more details on the known issues and limitations for the Blazor components.
+> Note: Partially generated components are marked with :construction:. See [Blazor Support](../blazor-support.md#known-issues-and-limitations) for more details on the known issues and limitations for Blazor components.
 
 ## Additional Resources
 


### PR DESCRIPTION
Update Blazor components limitations.
Closes #15657

_Note: in known issues we have now:_
 - _cannot generate - this means component supports the feature, but it is not generated, e.g. divider in card._
 - _does not support - this means component does not support this feature, e.g. date picker in dialog mode._